### PR TITLE
Different LDAP approach

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -1,5 +1,6 @@
 
 import ldap
+import os
 
 from flask import current_app, request, jsonify
 from flask_cors import cross_origin
@@ -8,6 +9,13 @@ from alerta.auth.utils import create_token, get_customers
 from alerta.exceptions import ApiError
 from alerta.models.user import User
 from . import auth
+
+# Define variables
+ldapurl = os.environ.get('LDAP_URL') or current_app.config["LDAP_URL"]
+binddn = os.environ.get('LDAP_BINDDN') or current_app.config["LDAP_BINDDN"]
+binddnpw = os.environ.get('LDAP_BINDDN_PW') or current_app.config["LDAP_BINDDN_PW"]
+ldapbasedn = os.environ.get('LDAP_BASEDN') or current_app.config["LDAP_BASEDN"]
+ldaprole = os.environ.get('LDAP_ROLE') or current_app.config["LDAP_ROLE"] or 'user'
 
 
 @auth.route('/auth/login', methods=['OPTIONS', 'POST'])
@@ -20,29 +28,39 @@ def login():
     except KeyError:
         raise ApiError("must supply 'username' and 'password'", 401)
 
-    username = email.split("@")[0]
-    domain = email.split("@")[1]
+    # Define ldap filter use %s for username
+    ldapfilter = f'(mail={email})'
 
-    # Validate LDAP domain
-    if domain not in current_app.config["LDAP_DOMAINS"]:
-        raise ApiError("unauthorized domain", 403)
+    # Attempt LDAP AUTH with binddn
+    try:
+        ldap_connection = ldap.initialize(ldapurl)
+        ldap_connection.simple_bind_s(binddn, binddnpw)
+    except ldap.INVALID_CREDENTIALS:
+        raise ApiError("invalid username or password for binddn", 401)
+    except Exception as e:
+        raise ApiError(str(e), 500)
 
-    userdn = current_app.config["LDAP_DOMAINS"][domain] % username
+    # Start LDAP search
+    try:
+        ldapquery = ldap_connection.search_s(ldapbasedn, ldap.SCOPE_SUBTREE, ldapfilter, ['cn'])
+        userdn = ldapquery[0][0]
+        usercn = str(b''.join(ldapquery[0][1]['cn']), 'utf-8')
+
+    except Exception:
+        raise ApiError("invalid username or basedn", 401)
 
     # Attempt LDAP AUTH
     try:
-        trace_level = 2 if current_app.debug else 0
-        ldap_connection = ldap.initialize(current_app.config['LDAP_URL'], trace_level=trace_level)
         ldap_connection.simple_bind_s(userdn, password)
     except ldap.INVALID_CREDENTIALS:
-        raise ApiError("invalid username or password", 401)
+        raise ApiError("invalid password", 401)
     except Exception as e:
         raise ApiError(str(e), 500)
 
     # Create user if not yet there
     user = User.find_by_email(email=email)
     if not user:
-        user = User(username, email, "", ["user"], "LDAP user", email_verified=True)
+        user = User(usercn, email, "", ldaprole.split(), "LDAP user", email_verified=True)
         user.create()
 
     # Check user is active
@@ -57,3 +75,4 @@ def login():
     token = create_token(user.id, user.name, user.email, provider='basic_ldap', customers=customers,
                          roles=user.roles, email=user.email, email_verified=user.email_verified)
     return jsonify(token=token.tokenize)
+


### PR DESCRIPTION
Several changes:
1) You can also use environment variables now.
2) Ldap search is used to find the User DN via mail attribute. For this we need a Bind DN.
3) Common name (cn) used as name in user creation.
4) You can set the default role which is used when the ldap user is created in database.
5) I removed the domain check. Currently only one LDAP server is supported.

Required variables:
LDAP_URL = LDAP server url
LDAP_BINDDN = Bind DN
LDAP_BINDDN_PW = Password for Bind DN
LDAP_BASEDN = Base DN for LDAP search

Optional:
LDAP_ROLE = Role for new LDAP users. Default is role 'user'.